### PR TITLE
[B] Make the major/minor detectors more strict

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,8 @@ const isMajorChange = (change) => {
 }
 
 const isMinorChange = (change) => {
-    const firstWord = change.split(': ')[0];
     return change.includes(':sparkles:') ||
-            firstWord === 'feat';
+            change.startsWith('feat: ');
 }
 
 /***

--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,9 @@ const isMajorChange = (change) => {
 }
 
 const isMinorChange = (change) => {
-    const firstWord = change.split(' ')[0];
+    const firstWord = change.split(': ')[0];
     return change.includes(':sparkles:') ||
-            firstWord.startsWith('feat');
+            firstWord === 'feat';
 }
 
 /***

--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,13 @@ const isMajorChange = (change) => {
     return change.includes(':boom:') ||
             change.includes('BREAKING CHANGE') ||
             change.includes('BREAKING_CHANGE') ||
-            firstWord.includes('!');
+            firstWord.endsWith('!:');
 }
 
 const isMinorChange = (change) => {
     const firstWord = change.split(' ')[0];
     return change.includes(':sparkles:') ||
-            firstWord.includes('feat');
+            firstWord.startsWith('feat');
 }
 
 /***


### PR DESCRIPTION
Based on the conventional commits [specification](https://www.conventionalcommits.org/en/v1.0.0/#specification):
> Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and **REQUIRED terminal colon and space**.

So in the case of a feature, `firstWord` will be `'feat:'`, yes the previous check would also work because it includes `'feat'`, but it would also work for `'defeat'`, `'feather'`, `'not-a-feature'`...

This PR makes the checking a bit more strict :)