### PR TITLE
Parameter to show or not the mention to the user

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const core = require('@actions/core');
 
 const URL = github.context.payload.pull_request.comments_url;
 const GITHUB_TOKEN = core.getInput("token") || process.env.token;
+const USE_MENTION = core.getInput("mention") || process.env.mention;
 const USER = github.context.payload.pull_request.user.login;
 
 /**
@@ -170,9 +171,7 @@ const postToGit = async (url, key, body) => {
         const fullTemplate = 
 `
 <section>
-    <p>
-        Hey @${USER}! Here's your changelog.
-    </p>
+    ${USE_MENTION ? `<p>Hey @${USER}! Here's your changelog.</p>` : ''}
     ${changesTemplate}
 </section>
 `;


### PR DESCRIPTION
# Addition of a parameter to show or not the mention to the user who made the pull request.

Note: Action is sensational, congratulations on the work done so far.

Motivation:
Use in personal projects, and to a certain extent, I work alone, but I like to keep the logs organized in releases, so with each successful pull request, I copy the changelog and paste it into a draft version. During this period, I see no reason to keep 'alerting' me, I don't mind, but I would like to be able to disable when necessary.